### PR TITLE
fix writing settings using inccorect WinmonCommand

### DIFF
--- a/src/VEBus.cpp
+++ b/src/VEBus.cpp
@@ -197,7 +197,7 @@ uint8_t VEBus::WriteViaID(Settings setting, int16_t rawValue, bool eeprom)
 	Data data;
 	if (!getNextFreeId_1(data.id)) return 0;
 	data.responseExpected = true;
-	data.command = WinmonCommand::WriteViaID;
+	data.command = WinmonCommand::WriteSetting;
 	data.address = setting;
 	data.expectedResponseCode = 0x88;
 	StorageType storageType = (eeprom == false) ? StorageType::NoEeprom : StorageType::Eeprom;
@@ -212,7 +212,7 @@ uint8_t VEBus::WriteViaID(Settings setting, uint16_t rawValue, bool eeprom)
 	Data data;
 	if (!getNextFreeId_1(data.id)) return 0;
 	data.responseExpected = true;
-	data.command = WinmonCommand::WriteViaID;
+	data.command = WinmonCommand::WriteSetting;
 	data.address = setting;
 	data.expectedResponseCode = 0x88;
 	StorageType storageType = (eeprom == false) ? StorageType::NoEeprom : StorageType::Eeprom;


### PR DESCRIPTION
This is a fix for the writing-settings problem mentioned in #1 I found reading through the code